### PR TITLE
Add dynamic agreement generation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
-# Trecasa-Quotes
+# Trecasa Dynamic Agreements
+
+This repository contains a lightweight Python toolchain for composing dynamic client agreements for Trecasa projects. Agreements are described with YAML templates that use double-brace placeholders (for example `{{ client.name }}`) and simple filters to adapt content, allowing you to toggle sections, iterate over deliverables, and format numbers as currency.
+
+## Features
+
+- **Template driven** – Author agreements in YAML with reusable sections.
+- **Conditional content** – Render sections only when their `when` expression evaluates to `True`.
+- **Data driven** – Supply engagement details through structured YAML data files.
+- **CLI workflow** – Use the `trecasa-agreement` command to preview or export agreements as Markdown.
+
+## Getting started
+
+1. Ensure Python 3.9+ is installed.
+2. (Optional) Install the project in editable mode to make the `trecasa-agreement` command available:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Render the sample agreement:
+
+   ```bash
+   python -m trecasa_quotes.cli generate \
+     --template templates/consulting_agreement.yaml \
+     --data examples/sample_agreement_data.yaml \
+     --preview
+   ```
+
+   To write the agreement to a file, pass `--output output/agreement.md`.
+
+## Template structure
+
+Agreement templates live in `templates/` as JSON-formatted YAML files and are composed of ordered `content` blocks:
+
+```yaml
+title: "{{ project_name }} Services Agreement"
+organization: "Trecasa"
+sections:
+  - heading: "Deliverables"
+    content:
+      - type: numbered
+        each: deliverables
+        template: "{{ item.title }} – {{ item.description }}"
+  - heading: "Financing Options"
+    when: pricing.installments
+    content:
+      - type: bullets
+        each: pricing.installments
+        template: "{{ item.due }}: {{ item.amount | currency }}"
+```
+
+Supported block types are:
+
+- `paragraph` – renders a block of text using placeholder substitution.
+- `bullets` – iterates over a list and prints bullet items (`item` and `index` are available during rendering).
+- `numbered` – iterates over a list and prints a numbered list.
+
+The optional `when` field evaluates truthiness of a dotted path (e.g. `pricing.installments`).
+
+## Tests
+
+Run the automated tests with:
+
+```bash
+python -m unittest discover -s tests
+```
+
+The tests validate template parsing, conditional rendering, and the custom currency filter.

--- a/examples/sample_agreement_data.yaml
+++ b/examples/sample_agreement_data.yaml
@@ -1,0 +1,45 @@
+{
+  "project_name": "Trecasa Modernization",
+  "agreement_date": "2024-03-15",
+  "client": {
+    "name": "Acme Holdings",
+    "contact": "Jamie Rivera"
+  },
+  "scope_of_work": [
+    "Design and build responsive landing pages",
+    "Implement CRM integration",
+    "Provide analytics dashboard setup"
+  ],
+  "project_timeline": {
+    "kickoff": "2024-04-01",
+    "completion": "2024-06-30"
+  },
+  "pricing": {
+    "total": 48000,
+    "deposit": 12000,
+    "installments": [
+      {
+        "due": "2024-05-01",
+        "amount": 18000
+      },
+      {
+        "due": "2024-06-01",
+        "amount": 18000
+      }
+    ]
+  },
+  "deliverables": [
+    {
+      "title": "Discovery Workshop",
+      "description": "Stakeholder interviews and requirements alignment"
+    },
+    {
+      "title": "Experience Design",
+      "description": "Wireframes and hi-fidelity mockups for approval"
+    },
+    {
+      "title": "Implementation",
+      "description": "Development, QA, and production launch support"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=65.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trecasa-quotes"
+version = "0.1.0"
+description = "Dynamic agreement generator for Trecasa"
+authors = [
+  { name = "Trecasa", email = "info@trecasa.com" }
+]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.scripts]
+trecasa-agreement = "trecasa_quotes.cli:main"
+

--- a/templates/consulting_agreement.yaml
+++ b/templates/consulting_agreement.yaml
@@ -1,0 +1,93 @@
+{
+  "title": "{{ project_name }} Services Agreement",
+  "organization": "Trecasa",
+  "sections": [
+    {
+      "heading": "Parties",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "This Services Agreement (\"Agreement\") is entered into on {{ agreement_date }} between {{ client.name }} (\"Client\") and {{ organization }} (\"Provider\")."
+        }
+      ]
+    },
+    {
+      "heading": "Engagement Overview",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Provider will deliver the following scope of work:"
+        },
+        {
+          "type": "bullets",
+          "each": "scope_of_work",
+          "template": "{{ item }}"
+        },
+        {
+          "type": "paragraph",
+          "text": "Project kickoff is targeted for {{ project_timeline.kickoff }} with an expected completion by {{ project_timeline.completion }}."
+        }
+      ]
+    },
+    {
+      "heading": "Investment",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "The total investment for this engagement is {{ pricing.total | currency }}."
+        },
+        {
+          "type": "paragraph",
+          "text": "A deposit of {{ pricing.deposit | currency }} is due upon signing."
+        }
+      ]
+    },
+    {
+      "heading": "Financing Options",
+      "when": "pricing.installments",
+      "content": [
+        {
+          "type": "bullets",
+          "each": "pricing.installments",
+          "template": "{{ item.due }}: {{ item.amount | currency }}"
+        }
+      ]
+    },
+    {
+      "heading": "Deliverables",
+      "content": [
+        {
+          "type": "numbered",
+          "each": "deliverables",
+          "template": "{{ item.title }} – {{ item.description }}"
+        }
+      ]
+    },
+    {
+      "heading": "Approvals",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Client approvals will be coordinated through {{ client.contact }}."
+        },
+        {
+          "type": "paragraph",
+          "text": "All change requests must be submitted in writing."
+        }
+      ]
+    },
+    {
+      "heading": "Signatures",
+      "content": [
+        {
+          "type": "paragraph",
+          "text": "Provider Representative: ________________________  Date: ____________"
+        },
+        {
+          "type": "paragraph",
+          "text": "Client Representative: {{ client.name }}          Date: ____________"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,56 @@
+import unittest
+from pathlib import Path
+
+from trecasa_quotes import AgreementRenderer, AgreementTemplate, AgreementTemplateError, load_agreement_data
+
+
+def fixture_path(name: str) -> Path:
+    return Path(__file__).parent.parent / name
+
+
+class AgreementRenderingTest(unittest.TestCase):
+    def test_rendering_includes_conditional_section(self) -> None:
+        template = AgreementTemplate.from_file(fixture_path("templates/consulting_agreement.yaml"))
+        data = load_agreement_data(fixture_path("examples/sample_agreement_data.yaml"))
+        renderer = AgreementRenderer()
+
+        output = renderer.render(template, data)
+
+        self.assertIn("Financing Options", output)
+        self.assertIn("$18,000.00", output)
+
+        data_no_financing = dict(data)
+        data_no_financing["pricing"] = {"total": 48000, "deposit": 12000}
+        output_without_financing = renderer.render(template, data_no_financing)
+        self.assertNotIn("Financing Options", output_without_financing)
+
+    def test_invalid_template_raises_error(self) -> None:
+        bad_template = fixture_path("tests") / "bad.yaml"
+        bad_template.write_text("{}", encoding="utf-8")
+        try:
+            with self.assertRaises(AgreementTemplateError):
+                AgreementTemplate.from_file(bad_template)
+        finally:
+            bad_template.unlink()
+
+    def test_currency_filter_rejects_invalid_value(self) -> None:
+        template = AgreementTemplate.from_dict(
+            {
+                "title": "Simple",
+                "sections": [
+                    {
+                        "heading": "Pricing",
+                        "content": [
+                            {"type": "paragraph", "text": "{{ value | currency }}"},
+                        ],
+                    }
+                ],
+            }
+        )
+        renderer = AgreementRenderer()
+        with self.assertRaises(AgreementTemplateError):
+            renderer.render(template, {"value": "not-a-number"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trecasa_quotes/__init__.py
+++ b/trecasa_quotes/__init__.py
@@ -1,0 +1,10 @@
+"""Trecasa Quotes dynamic agreement generator."""
+
+from .agreements import AgreementRenderer, AgreementTemplate, AgreementTemplateError, load_agreement_data
+
+__all__ = [
+    "AgreementRenderer",
+    "AgreementTemplate",
+    "AgreementTemplateError",
+    "load_agreement_data",
+]

--- a/trecasa_quotes/agreements.py
+++ b/trecasa_quotes/agreements.py
@@ -1,0 +1,274 @@
+"""Core agreement generation logic for Trecasa dynamic agreements."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+
+class AgreementTemplateError(RuntimeError):
+    """Raised when a template cannot be loaded or rendered."""
+
+
+_PLACEHOLDER_PATTERN = re.compile(r"{{\s*([^{}|]+?)(?:\s*\|\s*([a-zA-Z_][a-zA-Z0-9_]*))?\s*}}")
+
+
+def _format_currency(value: Any, currency_symbol: str = "$") -> str:
+    """Render a numeric value as a currency string."""
+
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive branch
+        raise AgreementTemplateError(f"Cannot format {value!r} as currency: {exc}") from exc
+    return f"{currency_symbol}{number:,.2f}"
+
+
+_FILTERS = {
+    "currency": _format_currency,
+}
+
+
+@dataclass
+class ParagraphBlock:
+    text: str
+
+
+@dataclass
+class BulletBlock:
+    each: str
+    template: str
+
+
+@dataclass
+class NumberedBlock:
+    each: str
+    template: str
+
+
+SectionBlock = ParagraphBlock | BulletBlock | NumberedBlock
+
+
+@dataclass
+class AgreementSection:
+    """Represents a section in the agreement."""
+
+    heading: str
+    blocks: List[SectionBlock] = field(default_factory=list)
+    when: Optional[str] = None
+
+
+class AgreementTemplate:
+    """Loads and renders agreement templates written as JSON mappings."""
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        sections: Iterable[AgreementSection],
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.title = title
+        self.sections = list(sections)
+        self.metadata = dict(metadata or {})
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AgreementTemplate":
+        if "title" not in data:
+            raise AgreementTemplateError("Template must define a 'title'.")
+        raw_sections = data.get("sections")
+        if not isinstance(raw_sections, Sequence) or not raw_sections:
+            raise AgreementTemplateError("Template must define at least one section in 'sections'.")
+        sections: List[AgreementSection] = []
+        for index, section_data in enumerate(raw_sections):
+            if not isinstance(section_data, Mapping):
+                raise AgreementTemplateError(f"Section {index} must be a mapping.")
+            heading = section_data.get("heading")
+            if heading is None:
+                raise AgreementTemplateError(f"Section {index} is missing required 'heading'.")
+            content = section_data.get("content")
+            if not isinstance(content, Sequence) or not content:
+                raise AgreementTemplateError(f"Section {index} must define a non-empty 'content' list.")
+            blocks = _parse_blocks(content, section_label=f"section {index}")
+            when = section_data.get("when")
+            if when is not None and not isinstance(when, str):
+                raise AgreementTemplateError(f"Section {index} condition must be a string if provided.")
+            sections.append(
+                AgreementSection(
+                    heading=str(heading),
+                    blocks=blocks,
+                    when=str(when) if when is not None else None,
+                )
+            )
+        metadata = {key: value for key, value in data.items() if key not in {"title", "sections"}}
+        return cls(title=str(data["title"]), sections=sections, metadata=metadata)
+
+    @classmethod
+    def from_file(cls, path: Path | str) -> "AgreementTemplate":
+        try:
+            file_path = Path(path)
+            loaded = json.loads(file_path.read_text(encoding="utf-8"))
+        except OSError as exc:  # pragma: no cover - filesystem failure
+            raise AgreementTemplateError(f"Unable to read template file: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise AgreementTemplateError(f"Unable to parse template file: {exc}") from exc
+        if not isinstance(loaded, Mapping):
+            raise AgreementTemplateError("Template file must contain a mapping at the top level.")
+        return cls.from_dict(loaded)
+
+
+def _parse_blocks(content: Sequence[Any], section_label: str) -> List[SectionBlock]:
+    blocks: List[SectionBlock] = []
+    for position, block in enumerate(content):
+        if not isinstance(block, Mapping):
+            raise AgreementTemplateError(f"{section_label} content entry {position} must be a mapping.")
+        block_type = block.get("type")
+        if block_type == "paragraph":
+            text = block.get("text")
+            if not isinstance(text, str):
+                raise AgreementTemplateError(f"{section_label} paragraph block requires a string 'text'.")
+            blocks.append(ParagraphBlock(text=text))
+        elif block_type == "bullets":
+            each = block.get("each")
+            template = block.get("template")
+            if not isinstance(each, str) or not isinstance(template, str):
+                raise AgreementTemplateError(f"{section_label} bullets block requires 'each' and 'template' strings.")
+            blocks.append(BulletBlock(each=each, template=template))
+        elif block_type == "numbered":
+            each = block.get("each")
+            template = block.get("template")
+            if not isinstance(each, str) or not isinstance(template, str):
+                raise AgreementTemplateError(f"{section_label} numbered block requires 'each' and 'template' strings.")
+            blocks.append(NumberedBlock(each=each, template=template))
+        else:
+            raise AgreementTemplateError(
+                f"{section_label} content entry {position} has unsupported type '{block_type}'."
+            )
+    return blocks
+
+
+def load_agreement_data(path: Path | str) -> Dict[str, Any]:
+    """Load agreement input data from a JSON-formatted file."""
+
+    file_path = Path(path)
+    try:
+        raw_text = file_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - filesystem failure
+        raise AgreementTemplateError(f"Unable to read data file: {exc}") from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise AgreementTemplateError(f"Unable to parse data file: {exc}") from exc
+    if not isinstance(data, MutableMapping):
+        raise AgreementTemplateError("Agreement data must be a mapping of keys to values.")
+    return dict(data)
+
+
+def _resolve_value(context: Mapping[str, Any], path: str, *, raise_if_missing: bool = True) -> Any:
+    current: Any = context
+    for segment in path.split("."):
+        segment = segment.strip()
+        if segment == "":
+            raise AgreementTemplateError("Empty path segment in placeholder.")
+        if isinstance(current, Mapping):
+            if segment not in current:
+                if raise_if_missing:
+                    raise AgreementTemplateError(f"Key '{segment}' not found while resolving '{path}'.")
+                return None
+            current = current[segment]
+        elif isinstance(current, Sequence) and not isinstance(current, (str, bytes)):
+            try:
+                index = int(segment)
+            except ValueError as exc:
+                raise AgreementTemplateError(f"Expected numeric index for list access in '{path}'.") from exc
+            try:
+                current = current[index]
+            except IndexError as exc:
+                raise AgreementTemplateError(f"Index {index} out of range while resolving '{path}'.") from exc
+        else:
+            if not hasattr(current, segment):
+                if raise_if_missing:
+                    raise AgreementTemplateError(f"Attribute '{segment}' not found while resolving '{path}'.")
+                return None
+            current = getattr(current, segment)
+    return current
+
+
+def _render_text(template_str: str, context: Mapping[str, Any]) -> str:
+    def replacer(match: re.Match[str]) -> str:
+        path = match.group(1).strip()
+        filter_name = match.group(2)
+        value = _resolve_value(context, path)
+        if filter_name:
+            filter_func = _FILTERS.get(filter_name)
+            if filter_func is None:
+                raise AgreementTemplateError(f"Unknown filter '{filter_name}'.")
+            value = filter_func(value)
+        return str(value)
+
+    return _PLACEHOLDER_PATTERN.sub(replacer, template_str)
+
+
+def _evaluate_condition(condition: str, context: Mapping[str, Any]) -> bool:
+    expr = condition.strip()
+    negate = False
+    if expr.startswith("not "):
+        negate = True
+        expr = expr[4:].strip()
+    value = _resolve_value(context, expr, raise_if_missing=False)
+    result = bool(value)
+    return not result if negate else result
+
+
+class AgreementRenderer:
+    """Renders agreements using lightweight template substitution."""
+
+    def render(self, template: AgreementTemplate, data: Mapping[str, Any]) -> str:
+        context: Dict[str, Any] = {}
+        context.update(template.metadata)
+        context.update(data)
+
+        title = _render_text(template.title, context)
+        parts: List[str] = [f"# {title}", ""]
+
+        for section in template.sections:
+            if section.when and not _evaluate_condition(section.when, context):
+                continue
+            heading = _render_text(section.heading, context)
+            parts.append(f"## {heading}")
+            parts.append("")
+
+            for block in section.blocks:
+                if isinstance(block, ParagraphBlock):
+                    parts.append(_render_text(block.text, context))
+                    parts.append("")
+                elif isinstance(block, BulletBlock):
+                    items = _resolve_value(context, block.each, raise_if_missing=True)
+                    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+                        raise AgreementTemplateError(
+                            f"Expected iterable for bullet list at '{block.each}'."
+                        )
+                    for index, item in enumerate(items, start=1):
+                        local_context = dict(context)
+                        local_context.update({"item": item, "index": index})
+                        parts.append(f"- {_render_text(block.template, local_context)}")
+                    if items:
+                        parts.append("")
+                elif isinstance(block, NumberedBlock):
+                    items = _resolve_value(context, block.each, raise_if_missing=True)
+                    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+                        raise AgreementTemplateError(
+                            f"Expected iterable for numbered list at '{block.each}'."
+                        )
+                    for index, item in enumerate(items, start=1):
+                        local_context = dict(context)
+                        local_context.update({"item": item, "index": index})
+                        rendered_item = _render_text(block.template, local_context)
+                        parts.append(f"{index}. {rendered_item}")
+                    if items:
+                        parts.append("")
+                else:  # pragma: no cover - defensive
+                    raise AgreementTemplateError("Unsupported block type encountered during rendering.")
+
+        return "\n".join(parts).rstrip() + "\n"

--- a/trecasa_quotes/cli.py
+++ b/trecasa_quotes/cli.py
@@ -1,0 +1,78 @@
+"""Command line interface for Trecasa dynamic agreements."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .agreements import AgreementRenderer, AgreementTemplate, AgreementTemplateError, load_agreement_data
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate Trecasa agreements from YAML templates and data inputs.")
+    subparsers = parser.add_subparsers(dest="command")
+
+    generate_parser = subparsers.add_parser("generate", help="Render an agreement by combining a template and data file.")
+    generate_parser.add_argument("--template", "-t", type=Path, required=True, help="Path to the YAML agreement template.")
+    generate_parser.add_argument("--data", "-d", type=Path, required=True, help="Path to the YAML data file used to fill the agreement.")
+    generate_parser.add_argument("--output", "-o", type=Path, help="Optional file to write the rendered agreement to.")
+    generate_parser.add_argument("--preview", action="store_true", help="Print the rendered agreement to STDOUT.")
+
+    explain_parser = subparsers.add_parser("explain", help="Show metadata about the template.")
+    explain_parser.add_argument("template", type=Path, help="Template file to inspect.")
+
+    return parser
+
+
+def _cmd_generate(args: argparse.Namespace) -> int:
+    try:
+        template_model = AgreementTemplate.from_file(args.template)
+        data_payload = load_agreement_data(args.data)
+        renderer = AgreementRenderer()
+        rendered = renderer.render(template_model, data_payload)
+    except AgreementTemplateError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+        print(f"Agreement written to {args.output}")
+
+    if args.preview or not args.output:
+        print(rendered)
+    return 0
+
+
+def _cmd_explain(args: argparse.Namespace) -> int:
+    try:
+        template_model = AgreementTemplate.from_file(args.template)
+    except AgreementTemplateError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Title: {template_model.title}")
+    if template_model.metadata:
+        print("Metadata:")
+        for key, value in template_model.metadata.items():
+            print(f"  {key}: {value}")
+    print("Sections:")
+    for index, section in enumerate(template_model.sections, start=1):
+        print(f"  {index}. {section.heading}")
+        if section.when:
+            print(f"     when: {section.when}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        return _cmd_generate(args)
+    if args.command == "explain":
+        return _cmd_explain(args)
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- implement a JSON-driven agreement template renderer with placeholder substitution, conditional sections, and list blocks
- add a command-line interface plus sample template and data files for generating agreements
- configure packaging metadata and unit tests covering conditional rendering and validation

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d38b3ead9883319e73f18d32d333a4